### PR TITLE
Updated discord link to a link that doesn't expire

### DIFF
--- a/src/components/MobileBetaStatus.tsx
+++ b/src/components/MobileBetaStatus.tsx
@@ -51,7 +51,7 @@ export default function MobileBetaStatus() {
       </Space>
       <Space>
         <Discord
-          href="https://discord.gg/ybRyHA8h"
+          href="https://discord.gg/DTMKf63ZSf"
           target="_blank"
           rel="noreferrer">
           <Image


### PR DESCRIPTION
Updated the discord link found in the social media bar to a link that doesn't expire. Link now redirects to discord. No other changes made