### PR TITLE
Navigation scrollbar shouldn't appear when there isnt anything to scroll

### DIFF
--- a/src/components/pages/Page.tsx
+++ b/src/components/pages/Page.tsx
@@ -33,7 +33,7 @@ export const Page: FunctionComponent<{
       <div className="relative container mx-auto flex flex-col align-center flex-grow p-8">
         {navBar}
         <nav className="w-full mb-7 border-b-2 border-blue-800">
-          <ul className="h-14 flex items-center gap-5 overflow-x-scroll">
+          <ul className="h-14 flex items-center gap-5 whitespace-nowrap overflow-auto scrollbar-hide">
             <li
               onClick={() => {
                 setCategory("general");


### PR DESCRIPTION
https://github.com/relaycc/relay/issues/78

When a mouse is plugged in on mac, a white scrollbar appears when there is nowhere to scroll
![Image 1-15-23 at 12 03 PM](https://user-images.githubusercontent.com/81312527/212564269-94600c2a-3ed1-4c47-b2df-d9b63263497d.jpeg)
